### PR TITLE
Disable Nginx sendfile in virtual env, refs #10322

### DIFF
--- a/tasks/pipeline-websrv-gunicorn.yml
+++ b/tasks/pipeline-websrv-gunicorn.yml
@@ -54,10 +54,6 @@
     dest: "/etc/nginx/sites-enabled/dashboard.conf"
     state: "link"
 
-- name: "Disable Nginx sendfile in virtual/dev environment"
-  lineinfile: dest=/etc/nginx/nginx.conf state=absent regexp='^[\s+]sendfile'
-  when: "is_dev|bool"
-
 # SSL configuration tasks - begin
 - name: "Template nginx ssl config file"
   template:

--- a/tasks/pipeline-websrv-gunicorn.yml
+++ b/tasks/pipeline-websrv-gunicorn.yml
@@ -54,6 +54,10 @@
     dest: "/etc/nginx/sites-enabled/dashboard.conf"
     state: "link"
 
+- name: "Disable Nginx sendfile in virtual/dev environment"
+  lineinfile: dest=/etc/nginx/nginx.conf state=absent regexp='^[\s+]sendfile'
+  when: "is_dev|bool"
+
 # SSL configuration tasks - begin
 - name: "Template nginx ssl config file"
   template:

--- a/templates/etc_nginx_sites_dashboard-gunicorn.conf.j2
+++ b/templates/etc_nginx_sites_dashboard-gunicorn.conf.j2
@@ -25,6 +25,10 @@ server {
   }
 
   location /media {
+{% if is_dev|bool %}
+    # dev environment: disable sendfile when serving static files (work around vagrant vboxsf issue)
+    sendfile off;
+{% endif %}
     alias /usr/share/archivematica/dashboard/media;
   }
 

--- a/templates/etc_nginx_sites_dashboard-ssl-gunicorn.conf.j2
+++ b/templates/etc_nginx_sites_dashboard-ssl-gunicorn.conf.j2
@@ -57,6 +57,10 @@ server {
   }
 
   location /media {
+{% if is_dev|bool %}
+    # dev environment: disable sendfile when serving static files (work around vagrant vboxsf issue)
+    sendfile off;
+{% endif %}
     alias /usr/share/archivematica/dashboard/media;
   }
 

--- a/templates/etc_nginx_sites_storage-gunicorn.conf.j2
+++ b/templates/etc_nginx_sites_storage-gunicorn.conf.j2
@@ -14,6 +14,10 @@ server {
     client_max_body_size 256M;
 
     location /static {
+{% if is_dev|bool %}
+       # dev environment: disable sendfile when serving static files (work around vagrant vboxsf issue)
+       sendfile off;
+{% endif %}
         alias /usr/lib/archivematica/storage-service/assets;
     }
 

--- a/templates/etc_nginx_sites_storage-ssl-gunicorn.conf.j2
+++ b/templates/etc_nginx_sites_storage-ssl-gunicorn.conf.j2
@@ -27,6 +27,10 @@ server {
     client_max_body_size 256M;
 
     location /static {
+{% if is_dev|bool %}
+        # dev environment: disable sendfile when serving static files (work around vagrant vboxsf issue)
+        sendfile off;
+{% endif %}
         alias /usr/lib/archivematica/storage-service/assets;
     }
 


### PR DESCRIPTION
The Linux kernel’s sendfile() operation doesn't work well in virtual
environments, truncating long static files. Nginx uses it by default
and this commit disables it if archivematica_src_environment_type
is set to 'development'