### PR TITLE
Make shared directory location configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,9 @@
 # directory to install source code
 archivematica_src_dir: "/opt/archivematica"
 
+# shared directory for processing, etc
+archivematica_src_shareddir: "/var/archivematica/sharedDirectory"
+
 # Components to install
 archivematica_src_install_sample_data: "yes"
 archivematica_src_install_am: "yes"

--- a/tasks/pipeline-osconf.yml
+++ b/tasks/pipeline-osconf.yml
@@ -51,19 +51,19 @@
   with_items:
     - "/var/log/archivematica/MCPServer"
 
-- name: "Clear /var/archivematica/sharedDirectory"
+- name: "Clear shared directory"
   file:
-    dest: "/var/archivematica/sharedDirectory"
+    dest: "{{ archivematica_src_shareddir }}"
     state: "absent"
   when: "archivematica_src_reset_shareddir|bool or archivematica_src_reset_am_all|bool"
 
-- name: "Create /var/archivematica/sharedDirectory"
+- name: "Create shared directory"
   file:
-    dest: "/var/archivematica/sharedDirectory"
+    dest: "{{ archivematica_src_shareddir }}"
     state: "directory"
 
-- name: "Create /var/archivematica/sharedDirectory structure"
-  command: "rsync -a {{ archivematica_src_dir }}/archivematica/src/MCPServer/share/sharedDirectoryStructure/ /var/archivematica/sharedDirectory/"
+- name: "Create shared directory structure"
+  command: "rsync -a {{ archivematica_src_dir }}/archivematica/src/MCPServer/share/sharedDirectoryStructure/ {{ archivematica_src_shareddir }}/"
 
 - name: "Set owner, group of /var/archivematica recursively"
   file:
@@ -73,9 +73,9 @@
     owner: "archivematica"
     group: "archivematica"
 
-- name: "Set owner, group of /var/archivematica/sharedDirectory recursively"
+- name: "Set owner, group of shared directory recursively"
   file:
-    dest: "/var/archivematica/sharedDirectory"
+    dest: "{{ archivematica_src_shareddir }}"
     state: "directory"
     recurse: "yes"
     owner: "archivematica"
@@ -86,9 +86,9 @@
     path: "/var/archivematica/"
     mode: "g+s"
 
-- name: "Set permissions for /var/archivematica/sharedDirectory"
+- name: "Set permissions for shared directory"
   file:
-    path: "/var/archivematica/sharedDirectory"
+    path: "{{ archivematica_src_shareddir }}"
     mode: 0664
 
 - name: "Set more permissions for /var/archivematica"

--- a/tasks/pipeline-osconf.yml
+++ b/tasks/pipeline-osconf.yml
@@ -62,6 +62,13 @@
     dest: "{{ archivematica_src_shareddir }}"
     state: "directory"
 
+- name: "Symlink shared directory to default location"
+  file:
+    src: "{{ archivematica_src_shareddir }}"
+    dest: "/var/archivematica/sharedDirectory"
+    state: "link"
+  when: archivematica_src_shareddir != "/var/archivematica/sharedDirectory"
+
 - name: "Create shared directory structure"
   command: "rsync -a {{ archivematica_src_dir }}/archivematica/src/MCPServer/share/sharedDirectoryStructure/ {{ archivematica_src_shareddir }}/"
 

--- a/templates/etc_archivematica_MCPClient_clientConfig.conf.j2
+++ b/templates/etc_archivematica_MCPClient_clientConfig.conf.j2
@@ -1,6 +1,6 @@
 [MCPClient]
 MCPArchivematicaServer = localhost:4730
-sharedDirectoryMounted = /var/archivematica/sharedDirectory/
+sharedDirectoryMounted = {{ archivematica_src_shareddir }}/
 maxThreads = 2
 archivematicaClientModules = {{ archivematica_src_clientmodules }}
 clientScriptsDirectory = /usr/lib/archivematica/MCPClient/clientScripts/
@@ -9,6 +9,6 @@ LoadSupportedCommandsSpecial = True
 numberOfTasks = 0
 elasticsearchServer = localhost:9200
 disableElasticsearchIndexing = False
-temp_dir = /var/archivematica/sharedDirectory/tmp
+temp_dir = {{ archivematica_src_shareddir }}/tmp
 kioskMode = False
 django_settings_module = settings.common

--- a/templates/etc_archivematica_MCPServer_serverConfig.conf.j2
+++ b/templates/etc_archivematica_MCPServer_serverConfig.conf.j2
@@ -3,9 +3,9 @@
 [MCPServer]
 MCPArchivematicaServer  =  localhost:4730
 GearmanServerWorker = localhost:4730
-watchDirectoryPath  =  /var/archivematica/sharedDirectory/watchedDirectories/
-sharedDirectory  =  /var/archivematica/sharedDirectory/
-processingDirectory  =  /var/archivematica/sharedDirectory/currentlyProcessing/
+watchDirectoryPath  =  {{ archivematica_src_shareddir }}/watchedDirectories/
+sharedDirectory  =  {{ archivematica_src_shareddir }}/
+processingDirectory  =  {{ archivematica_src_shareddir }}/currentlyProcessing/
 rejectedDirectory  =  %%sharedPath%%rejected/
 watchDirectoriesPollInterval = 1
 processingXMLFile = processingMCP.xml


### PR DESCRIPTION
I prefer to have my shared directory on a different filesystem, so I just replaced instances of `/var/archivematica/sharedDirectory` with a new ansible variable `archivematica_src_shareddir`.
