### PR TITLE
Fix /var/archivematica/ related tasks

### DIFF
--- a/tasks/pipeline-osconf.yml
+++ b/tasks/pipeline-osconf.yml
@@ -57,49 +57,40 @@
     state: "absent"
   when: "archivematica_src_reset_shareddir|bool or archivematica_src_reset_am_all|bool"
 
-- name: "Create shared directory"
+# to avoid playbook errors when the shared dir is a symlink, 
+# check for existence before creating 
+- name: "Check if shared directory exists"
+  stat:
+    path: "{{ archivematica_src_shareddir }}"
+  register: "shareddir_st"
+
+- set_fact:
+    create_shareddir: true
+  when: "shareddir_st.stat.exists is defined and not shareddir_st.stat.exists" 
+
+- set_fact:
+    create_shareddir: false
+  when: "shareddir_st.stat.exists is defined and shareddir_st.stat.exists" 
+
+- name: "Create shared directory (if it doesn't exist and there is no symlink to it)"
   file:
     dest: "{{ archivematica_src_shareddir }}"
     state: "directory"
+    owner: "archivematica"
+    group: "archivematica"
+  when: "create_shareddir"
 
+# (this is required because some hardcoding of the shared dir remains in archivematica code)
 - name: "Symlink shared directory to default location"
   file:
     src: "{{ archivematica_src_shareddir }}"
     dest: "/var/archivematica/sharedDirectory"
     state: "link"
-  when: archivematica_src_shareddir != "/var/archivematica/sharedDirectory"
+  when: create_shareddir and archivematica_src_shareddir != "/var/archivematica/sharedDirectory"
 
-- name: "Create shared directory structure"
-  command: "rsync -a {{ archivematica_src_dir }}/archivematica/src/MCPServer/share/sharedDirectoryStructure/ {{ archivematica_src_shareddir }}/"
-
-- name: "Set owner, group of /var/archivematica recursively"
-  file:
-    dest: "/var/archivematica"
-    state: "directory"
-    recurse: "yes"
-    owner: "archivematica"
-    group: "archivematica"
-
-- name: "Set owner, group of shared directory recursively"
-  file:
-    dest: "{{ archivematica_src_shareddir }}"
-    state: "directory"
-    recurse: "yes"
-    owner: "archivematica"
-    group: "archivematica"
-
-- name: "Set permissions for /var/archivematica"
-  file:
-    path: "/var/archivematica/"
-    mode: "g+s"
-
-- name: "Set permissions for shared directory"
-  file:
-    path: "{{ archivematica_src_shareddir }}"
-    mode: 0664
-
-- name: "Set more permissions for /var/archivematica"
-  shell: "find -L /var/archivematica/ -print0 -type d  | sudo xargs -IF -0 chmod u+rwx,g+rwxt,o-rwx F"
+# this should be executed also for upgrades (to reflect changes) 
+- name: "Copy shared directory structure"
+  command: "rsync -a --chown=archivematica:archivematica {{ archivematica_src_dir }}/archivematica/src/MCPServer/share/sharedDirectoryStructure/ {{ archivematica_src_shareddir }}/"
 
 - name: "Create subdirectories for archivematica-mcp-client source files"
   file:

--- a/tasks/ss-db.yml
+++ b/tasks/ss-db.yml
@@ -27,13 +27,12 @@
     virtualenv: "/usr/share/python/archivematica-storage-service"
   environment: "{{ archivematica_src_ss_environment }}"
 
-- name: "Fix DB permissions after reset"
+- name: "Fix DB permissions"
   file:
     dest: "{{ archivematica_src_ss_env_ss_db_name }}"
     owner: "archivematica"
     group: "archivematica"
     mode: "u=rwX,g=rwX,o=rX"
-  when: "archivematica_src_reset_ss_db|bool"
 
 - name: "Back create API keys for old users"
   django_manage:

--- a/tasks/ss-main.yml
+++ b/tasks/ss-main.yml
@@ -121,13 +121,22 @@
 #   3- OS configuration (user/directory/file creation/permissions/ownership )
 ###########################################################
 
-- name: "Create subdirectories for archivematica-storage-service source files (ref. debian/archivematica-storage-service.install)"
+- name: "Create subdirectory for archivematica-storage-service source files"
   file:
     dest: "{{ item }}"
     state: "directory"
   with_items:
-    - "/var/archivematica/storage-service"
     - "/usr/lib/archivematica"
+  tags: "amsrc-ss-osconf"
+
+- name: "Create subdirectory for archivematica-storage-service database file"
+  file:
+    dest: "{{ item }}"
+    state: "directory"
+    owner: "archivematica"
+    group: "archivematica"
+  with_items:
+    - "/var/archivematica/storage-service"
   tags: "amsrc-ss-osconf"
 
 - name: "Create subdirectories for archivematica-storage-service config"
@@ -136,16 +145,6 @@
     state: "directory"
   with_items:
     - "/etc/archivematica"
-  tags: "amsrc-ss-osconf"
-
-- name: "Set owner, group, mode of /var/archivematica recursively"
-  file:
-    dest: "/var/archivematica"
-    state: "directory"
-    recurse: "yes"
-    owner: "archivematica"
-    group: "archivematica"
-    mode: "u=rwX,g=rwX,o=rX"
   tags: "amsrc-ss-osconf"
 
 - name: "Create archivematica-storage-service log directories"


### PR DESCRIPTION
- Check if shared directory exists before attempting to create it (to
  avoid errors when it is a symlink)
- Remove unrequired time-consuming commands that change owner/
  permissions of objects inside /var/archivematica