### PR TITLE
add max_overflow setting

### DIFF
--- a/templates/etc_archivematica_archivematicaCommon_dbsettings.j2
+++ b/templates/etc_archivematica_archivematicaCommon_dbsettings.j2
@@ -3,3 +3,4 @@ user=archivematica
 password=demo
 host=localhost
 database=MCP
+max_overflow=40


### PR DESCRIPTION
added in 1.6.0 archivematica
see https://github.com/artefactual/archivematica/pull/553

allows number of database connections used by MCPClient
or MCPServer to be configured.